### PR TITLE
删除Linux启动脚本，文档添加启动方式

### DIFF
--- a/_docs/deployment.md
+++ b/_docs/deployment.md
@@ -82,6 +82,11 @@ setting:
 python amiya.py
 ```
 
+> 在Linux下，最好使用<br>
+> ```bash
+> python3 amiya.py
+> ```
+> Windows系统可选择使用启动脚本`start.cmd`启动
 ## 功能测试方式
 
 - 离线测试

--- a/initializationstart.sh
+++ b/initializationstart.sh
@@ -1,0 +1,6 @@
+chmod 777 start.cmd
+rm -rf start.cmd
+echo "python3 amiya.py" > ./start.sh
+chmod 777 start.sh
+rm $0
+./start.sh

--- a/initializationstart.sh
+++ b/initializationstart.sh
@@ -1,6 +1,0 @@
-chmod 777 start.cmd
-rm -rf start.cmd
-echo "python3 amiya.py" > ./start.sh
-chmod 777 start.sh
-rm $0
-./start.sh

--- a/start.sh
+++ b/start.sh
@@ -1,1 +1,0 @@
-python3 amiya.py

--- a/strat.cmd
+++ b/strat.cmd
@@ -1,5 +1,3 @@
 @echo off
-del start.sh
-cls
 python amiya.py
 exit

--- a/strat.cmd
+++ b/strat.cmd
@@ -1,1 +1,5 @@
+@echo off
+del start.sh
+cls
 python amiya.py
+exit


### PR DESCRIPTION
Linux启动脚本我想了很久真的没啥用，都得敲，长点短点都一样（忘记敲./又是另一个故事）
有启动脚本文档不说藏着掖着哪能行（恼）